### PR TITLE
Fix misnamed type-check helper

### DIFF
--- a/src/Rule.php
+++ b/src/Rule.php
@@ -107,7 +107,7 @@ class Rule
 
     private function isPropositionOrVariable(RuleElement $element): bool
     {
-        return $element->getType()->isOnOf(RuleElementType::PROPOSITION, RuleElementType::VARIABLE);
+        return $element->getType()->isOneOf(RuleElementType::PROPOSITION, RuleElementType::VARIABLE);
     }
 
     private function process(GenericList $elements): Proposition
@@ -133,7 +133,7 @@ class Rule
 
     private function isOperator(RuleElement $ruleElement): bool
     {
-        return $ruleElement->getType()->isOnOf(RuleElementType::OPERATOR);
+        return $ruleElement->getType()->isOneOf(RuleElementType::OPERATOR);
     }
 
     private function processOperator(array &$stack, Operator $ruleElement): void

--- a/src/RuleElementType.php
+++ b/src/RuleElementType.php
@@ -8,7 +8,7 @@ enum RuleElementType
     case PROPOSITION;
     case VARIABLE;
 
-    public function isOnOf(self $type, self ...$others): bool
+    public function isOneOf(self $type, self ...$others): bool
     {
         return in_array($this, [$type, ...$others], true);
     }


### PR DESCRIPTION
## Summary
- rename `isOnOf` to `isOneOf` in `RuleElementType`
- update references in `Rule`

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68418fec8b988330974901b9b84a3289