### PR TITLE
Return Either from evaluate methods

### DIFF
--- a/src/Rule.php
+++ b/src/Rule.php
@@ -3,6 +3,7 @@
 namespace JakubCiszak\RuleEngine;
 
 use Munus\Collection\GenericList;
+use Munus\Control\Either;
 
 class Rule
 {
@@ -72,10 +73,14 @@ class Rule
         return $this;
     }
 
-    public function evaluate(RuleContext $context): Proposition
+    public function evaluate(RuleContext $context): Either
     {
         $this->elements->forEach(fn (RuleElement $element) => $this->prepareElement($element, $context));
-        return $this->process($this->elements);
+        $result = $this->process($this->elements);
+
+        return $result->getValue()
+            ? Either::right($result)
+            : Either::left($result);
     }
 
     private function prepareElement(RuleElement $element, RuleContext $context): bool

--- a/src/Ruleset.php
+++ b/src/Ruleset.php
@@ -2,6 +2,8 @@
 
 namespace JakubCiszak\RuleEngine;
 
+use Munus\Control\Either;
+
 class Ruleset
 {
     /**
@@ -15,15 +17,16 @@ class Ruleset
         $this->rules = $rules;
     }
 
-    public function evaluate(RuleContext $context): Proposition
+    public function evaluate(RuleContext $context): Either
     {
-        $result = Proposition::create('', false);
+        $result = Either::right(Proposition::success());
         foreach ($this->rules as $rule) {
             $result = $rule->evaluate($context);
-            if ($result->getValue() === false) {
+            if ($result->isLeft()) {
                 return $result;
             }
         }
+
         return $result;
     }
 }

--- a/tests/RuleTest.php
+++ b/tests/RuleTest.php
@@ -52,9 +52,10 @@ class RuleTest extends TestCase
             ->variable('state', 'active')
             ->variable('invalidState', 'inactive');
 
-        $proposition = $rule->evaluate($context);
+        $result = $rule->evaluate($context);
 
-        self::assertFalse($proposition->getValue());
+        self::assertTrue($result->isLeft());
+        self::assertFalse($result->getLeft()->getValue());
     }
 
     public function testShouldEvaluationSuccess(): void
@@ -87,8 +88,9 @@ class RuleTest extends TestCase
             ->variable('id', 1)
             ->proposition('ruleProposition', fn () => false);
 
-        $proposition = $rule->evaluate($context);
+        $result = $rule->evaluate($context);
 
-        self::assertTrue($proposition->getValue());
+        self::assertTrue($result->isRight());
+        self::assertTrue($result->get()->getValue());
     }
 }

--- a/tests/RulesetTest.php
+++ b/tests/RulesetTest.php
@@ -12,14 +12,18 @@ class RulesetTest extends TestCase
     {
         $ruleset = RuleFixtureBuilder::some()->withTrueProposition()->get();
 
-        $this->assertTrue($ruleset->evaluate(new RuleContext())->getValue());
+        $result = $ruleset->evaluate(new RuleContext());
+        $this->assertTrue($result->isRight());
+        $this->assertTrue($result->get()->getValue());
     }
 
     public function testShouldEvaluationFail(): void
     {
         $ruleset = RuleFixtureBuilder::some()->withFalseProposition()->get();
 
-        $this->assertFalse($ruleset->evaluate(new RuleContext())->getValue());
+        $result = $ruleset->evaluate(new RuleContext());
+        $this->assertTrue($result->isLeft());
+        $this->assertFalse($result->getLeft()->getValue());
     }
 
 }


### PR DESCRIPTION
## Summary
- return Munus Either objects from `Rule::evaluate` and `Ruleset::evaluate`
- adjust tests for new Either API

## Testing
- `Codex couldn't run certain commands due to environnment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_684193071dec833091885096c6572583