### PR TITLE
Add JsonRule context

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,35 @@ $context = new RuleContext();
 $result = $rule->evaluate($context);
 ```
 
+### JsonRPN context
+
+Rules can also be defined using JSON in RPN order. The example below presents two rules:
+
+```json
+{
+  "rules": [
+    {
+      "name": "rule1",
+      "elements": [
+        {"type": "variable", "name": "a"},
+        {"type": "variable", "name": "b"},
+        {"type": "operator", "name": "EQUAL_TO"}
+      ]
+    },
+    {
+      "name": "rule2",
+      "elements": [
+        {"type": "variable", "name": "amount"},
+        {"type": "variable", "name": "max"},
+        {"type": "operator", "name": "GREATER_THAN"}
+      ]
+    }
+  ]
+}
+```
+
+This JSON can be passed to the `JsonRPN` context to get the evaluation result in the same structure.
+
 ## Development
 
 ### Running Tests

--- a/src/Api/JsonRPN.php
+++ b/src/Api/JsonRPN.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace JakubCiszak\RuleEngine\Api;
+
+use InvalidArgumentException;
+use JakubCiszak\RuleEngine\{Rule, RuleContext, Operator, Variable, Proposition};
+
+final class JsonRPN
+{
+    private function __construct()
+    {
+    }
+
+    /**
+     * @param string $rulesetJson JSON describing rules in RPN notation
+     * @param string $contextJson JSON describing context variables and propositions
+     *
+     * @throws \JsonException
+     */
+    public static function evaluate(string $rulesetJson, string $contextJson = '{}'): string
+    {
+        $rulesData = json_decode($rulesetJson, true, 512, JSON_THROW_ON_ERROR);
+        $contextData = json_decode($contextJson, true, 512, JSON_THROW_ON_ERROR);
+
+        if (!isset($rulesData['rules']) || !is_array($rulesData['rules'])) {
+            throw new InvalidArgumentException('Invalid rules JSON');
+        }
+
+        $context = self::createContext($contextData);
+        $results = [];
+
+        foreach ($rulesData['rules'] as $ruleData) {
+            $rule = self::createRule($ruleData);
+            $result = $rule->evaluate($context);
+            $value = $result->isRight()
+                ? $result->get()->getValue()
+                : $result->getLeft()->getValue();
+            $results[] = ['name' => $rule->name, 'value' => $value];
+        }
+
+        return json_encode(['results' => $results], JSON_THROW_ON_ERROR);
+    }
+
+    private static function createRule(array $data): Rule
+    {
+        $rule = new Rule($data['name'] ?? uniqid('rule_', true));
+        foreach ($data['elements'] ?? [] as $element) {
+            $type = $element['type'] ?? null;
+            $name = $element['name'] ?? null;
+            if ($type === 'operator') {
+                $rule->addElement(Operator::create($name));
+                continue;
+            }
+            if ($type === 'variable') {
+                $rule->addElement(Variable::create($name, $element['value'] ?? null));
+                continue;
+            }
+            if ($type === 'proposition') {
+                $rule->addElement(Proposition::create($name, $element['value'] ?? true));
+                continue;
+            }
+            throw new InvalidArgumentException('Invalid rule element');
+        }
+        return $rule;
+    }
+
+    private static function createContext(array $data): RuleContext
+    {
+        $context = new RuleContext();
+        foreach ($data as $name => $value) {
+            if (is_bool($value)) {
+                $context->proposition($name, $value);
+            } else {
+                $context->variable($name, $value);
+            }
+        }
+        return $context;
+    }
+}

--- a/tests/JsonRPNTest.php
+++ b/tests/JsonRPNTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace JakubCiszak\RuleEngine\Tests;
+
+use JakubCiszak\RuleEngine\Api\JsonRPN;
+use PHPUnit\Framework\TestCase;
+
+final class JsonRPNTest extends TestCase
+{
+    public function testEvaluateJsonRPNs(): void
+    {
+        $rulesJson = json_encode([
+            'rules' => [
+                [
+                    'name' => 'rule1',
+                    'elements' => [
+                        ['type' => 'variable', 'name' => 'a'],
+                        ['type' => 'variable', 'name' => 'b'],
+                        ['type' => 'operator', 'name' => 'EQUAL_TO'],
+                    ],
+                ],
+                [
+                    'name' => 'rule2',
+                    'elements' => [
+                        ['type' => 'variable', 'name' => 'max'],
+                        ['type' => 'variable', 'name' => 'amount'],
+                        ['type' => 'operator', 'name' => 'GREATER_THAN'],
+                    ],
+                ],
+            ],
+        ], JSON_THROW_ON_ERROR);
+
+        $contextJson = json_encode([
+            'a' => 1,
+            'b' => 1,
+            'amount' => 50,
+            'max' => 100,
+        ], JSON_THROW_ON_ERROR);
+
+        $resultJson = JsonRPN::evaluate($rulesJson, $contextJson);
+        $result = json_decode($resultJson, true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertTrue($result['results'][0]['value']);
+        $this->assertFalse($result['results'][1]['value']);
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `JsonRule` context for evaluating rules defined in JSON
- add PHPUnit tests for JSON evaluation
- document JSON rule usage in README

## Testing
- `composer install`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_688ba8f54d788330af019e4a45be4975