### PR TITLE
Add ruleset support for JsonRule

### DIFF
--- a/tests/JsonRuleTest.php
+++ b/tests/JsonRuleTest.php
@@ -75,4 +75,36 @@ final class JsonRuleTest extends TestCase
 
         self::assertTrue(JsonRule::evaluate($rules, $data));
     }
+
+    public function testEvaluateRulesetArray(): void
+    {
+        $ruleset = [
+            'rule1' => ['and' => [
+                ['<' => [['var' => 'temp'], 110]],
+                ['==' => [['var' => 'pie.filling'], 'apple']],
+            ]],
+            'rule2' => ['and' => [
+                ['<' => [['var' => 'temp'], 110]],
+                ['==' => [['var' => 'pie.filling'], 'apple']],
+            ]],
+        ];
+
+        $data = ['temp' => 100, 'pie' => ['filling' => 'apple']];
+
+        self::assertTrue(JsonRule::evaluate($ruleset, $data));
+    }
+
+    public function testEvaluateRulesetJson(): void
+    {
+        $ruleset = [
+            'rule1' => ['==' => [['var' => 'a'], 1]],
+            'rule2' => ['>' => [['var' => 'b'], 2]],
+        ];
+        $data = ['a' => 1, 'b' => 3];
+
+        $rulesetJson = json_encode($ruleset, JSON_THROW_ON_ERROR);
+        $dataJson = json_encode($data, JSON_THROW_ON_ERROR);
+
+        self::assertTrue(JsonRule::evaluate($rulesetJson, $dataJson));
+    }
 }


### PR DESCRIPTION
## Summary
- extend `JsonRule` to handle a set of rules via `Ruleset`
- implement detection of ruleset arrays
- replace rule object loop with `array_map`
- refactor logical expression handling with `array_map`
- cover the new functionality with unit tests

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_688bcb7ccb348330ae81f93e2c593f96