### PR TITLE
Return Proposition from evaluation

### DIFF
--- a/src/Api/JsonRPN.php
+++ b/src/Api/JsonRPN.php
@@ -32,10 +32,7 @@ final class JsonRPN
         foreach ($rulesData['rules'] as $ruleData) {
             $rule = self::createRule($ruleData);
             $result = $rule->evaluate($context);
-            $value = $result->isRight()
-                ? $result->get()->getValue()
-                : $result->getLeft()->getValue();
-            $results[] = ['name' => $rule->name, 'value' => $value];
+            $results[] = ['name' => $rule->name, 'value' => $result->getValue()];
         }
 
         return json_encode(['results' => $results], JSON_THROW_ON_ERROR);

--- a/src/Api/JsonRule.php
+++ b/src/Api/JsonRule.php
@@ -46,13 +46,13 @@ final class JsonRule
 
             $ruleset = new Ruleset(...$ruleObjects);
             $result = $ruleset->evaluate($context);
-            return $result->isRight();
+            return $result->getValue();
         }
 
         $rule = new Rule('json_rule');
         self::parseExpression($rules, $rule, $data);
         $result = $rule->evaluate($context);
-        return $result->isRight();
+        return $result->getValue();
     }
 
     private static function parseExpression(mixed $expr, Rule $rule, array $data): void

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -3,7 +3,6 @@
 namespace JakubCiszak\RuleEngine;
 
 use Munus\Collection\GenericList;
-use Munus\Control\Either;
 
 class Rule
 {
@@ -73,14 +72,10 @@ class Rule
         return $this;
     }
 
-    public function evaluate(RuleContext $context): Either
+    public function evaluate(RuleContext $context): Proposition
     {
         $this->elements->forEach(fn (RuleElement $element) => $this->prepareElement($element, $context));
-        $result = $this->process($this->elements);
-
-        return $result->getValue()
-            ? Either::right($result)
-            : Either::left($result);
+        return $this->process($this->elements);
     }
 
     private function prepareElement(RuleElement $element, RuleContext $context): bool

--- a/src/Ruleset.php
+++ b/src/Ruleset.php
@@ -2,8 +2,6 @@
 
 namespace JakubCiszak\RuleEngine;
 
-use Munus\Control\Either;
-
 class Ruleset
 {
     /**
@@ -17,12 +15,12 @@ class Ruleset
         $this->rules = $rules;
     }
 
-    public function evaluate(RuleContext $context): Either
+    public function evaluate(RuleContext $context): Proposition
     {
-        $result = Either::right(Proposition::success());
+        $result = Proposition::success();
         foreach ($this->rules as $rule) {
             $result = $rule->evaluate($context);
-            if ($result->isLeft()) {
+            if (!$result->getValue()) {
                 return $result;
             }
         }

--- a/tests/RuleTest.php
+++ b/tests/RuleTest.php
@@ -5,6 +5,7 @@ namespace JakubCiszak\RuleEngine\Tests;
 use DateTimeImmutable;
 use JakubCiszak\RuleEngine\Rule;
 use JakubCiszak\RuleEngine\RuleContext;
+use JakubCiszak\RuleEngine\Proposition;
 use PHPUnit\Framework\TestCase;
 
 class RuleTest extends TestCase
@@ -54,8 +55,8 @@ class RuleTest extends TestCase
 
         $result = $rule->evaluate($context);
 
-        self::assertTrue($result->isLeft());
-        self::assertFalse($result->getLeft()->getValue());
+        self::assertInstanceOf(Proposition::class, $result);
+        self::assertFalse($result->getValue());
     }
 
     public function testShouldEvaluationSuccess(): void
@@ -90,7 +91,7 @@ class RuleTest extends TestCase
 
         $result = $rule->evaluate($context);
 
-        self::assertTrue($result->isRight());
-        self::assertTrue($result->get()->getValue());
+        self::assertInstanceOf(Proposition::class, $result);
+        self::assertTrue($result->getValue());
     }
 }

--- a/tests/RulesetTest.php
+++ b/tests/RulesetTest.php
@@ -2,6 +2,7 @@
 
 namespace JakubCiszak\RuleEngine\Tests;
 
+use JakubCiszak\RuleEngine\Proposition;
 use JakubCiszak\RuleEngine\RuleContext;
 use JakubCiszak\RuleEngine\Tests\Fixtures\RuleFixtureBuilder;
 use PHPUnit\Framework\TestCase;
@@ -13,8 +14,8 @@ class RulesetTest extends TestCase
         $ruleset = RuleFixtureBuilder::some()->withTrueProposition()->get();
 
         $result = $ruleset->evaluate(new RuleContext());
-        $this->assertTrue($result->isRight());
-        $this->assertTrue($result->get()->getValue());
+        $this->assertInstanceOf(Proposition::class, $result);
+        $this->assertTrue($result->getValue());
     }
 
     public function testShouldEvaluationFail(): void
@@ -22,8 +23,8 @@ class RulesetTest extends TestCase
         $ruleset = RuleFixtureBuilder::some()->withFalseProposition()->get();
 
         $result = $ruleset->evaluate(new RuleContext());
-        $this->assertTrue($result->isLeft());
-        $this->assertFalse($result->getLeft()->getValue());
+        $this->assertInstanceOf(Proposition::class, $result);
+        $this->assertFalse($result->getValue());
     }
 
 }


### PR DESCRIPTION
## Summary
- drop Either return type from `Rule::evaluate` and `Ruleset::evaluate`
- adapt JSON APIs to use `Proposition` results
- update tests for the new API

## Testing
- `./vendor/bin/phpunit`
