### PR TITLE
Implement ActivityRule decorator

### DIFF
--- a/src/ActivityRule.php
+++ b/src/ActivityRule.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace JakubCiszak\RuleEngine;
+
+use Closure;
+
+/**
+ * @template T of callable(RuleContext): mixed
+ */
+final class ActivityRule
+{
+    /** @var T */
+    private readonly Closure $activity;
+
+    /**
+     * @param Rule $rule
+     * @param T $activity
+     */
+    public function __construct(
+        private readonly Rule $rule,
+        callable $activity
+    ) {
+        $this->activity = Closure::fromCallable($activity);
+    }
+
+    public function evaluate(RuleContext $context): Proposition
+    {
+        $result = $this->rule->evaluate($context);
+        ($this->activity)($context);
+        return $result;
+    }
+}

--- a/tests/ActivityRuleTest.php
+++ b/tests/ActivityRuleTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace JakubCiszak\RuleEngine\Tests;
+
+use JakubCiszak\RuleEngine\ActivityRule;
+use JakubCiszak\RuleEngine\Rule;
+use JakubCiszak\RuleEngine\RuleContext;
+use JakubCiszak\RuleEngine\Variable;
+use JakubCiszak\RuleEngine\Proposition;
+use PHPUnit\Framework\TestCase;
+
+class ActivityRuleTest extends TestCase
+{
+    public function testEvaluateDecoratesRule(): void
+    {
+        $rule = new Rule('someRule');
+        $rule->variable('a')
+            ->variable('b')
+            ->equalTo();
+
+        $called = false;
+        $activity = function (RuleContext $context) use (&$called) {
+            $called = true;
+            $context->variable('activity', true);
+        };
+
+        $activityRule = new ActivityRule($rule, $activity);
+
+        $context = new RuleContext();
+        $context->variable('a', 1)
+            ->variable('b', 1);
+
+        $result = $activityRule->evaluate($context);
+
+        $this->assertInstanceOf(Proposition::class, $result);
+        $this->assertTrue($result->getValue());
+        $this->assertTrue($called);
+        $variable = $context->findElement(Variable::create('activity'));
+        $this->assertInstanceOf(Variable::class, $variable);
+        $this->assertTrue($variable->getValue());
+    }
+}


### PR DESCRIPTION
## Summary
- add `ActivityRule` for executing extra activities during evaluation
- test decorator logic to ensure callable is invoked

## Testing
- `./vendor/bin/phpunit -c phpunit.xml --stop-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_688d13a04ad08330b4a56c42b29bf189