### PR TITLE
Add action examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,38 @@ Rules can also be defined using JSON in RPN order. The example below presents tw
 
 This JSON can be passed to the `JsonRPN` context to get the evaluation result in the same structure.
 
-#### Rule actions
+
+### JsonRule format
+
+`JsonRule` accepts rules defined using a JSON structure that resembles infix notation. Operators are written as keys and their arguments are provided in nested arrays.
+
+```php
+use JakubCiszak\RuleEngine\Api\JsonRule;
+
+$rules = ['and' => [
+    ['<' => [['var' => 'temp'], 110]],
+    ['==' => [['var' => 'pie.filling'], 'apple']],
+]];
+
+$data = ['temp' => 100, 'pie' => ['filling' => 'apple']];
+
+$result = JsonRule::evaluate($rules, $data); // true
+```
+
+You can also pass a set of named rules for evaluation:
+
+```php
+$ruleset = [
+    'rule1' => ['==' => [['var' => 'a'], 1]],
+    'rule2' => ['>' => [['var' => 'b'], 2]],
+];
+
+$data = ['a' => 1, 'b' => 3];
+
+JsonRule::evaluate($ruleset, $data); // true
+```
+
+### Rule actions
 
 Each rule may include simple actions executed when the rule is evaluated. Actions are expressed as strings:
 
@@ -142,36 +173,6 @@ $data = ['a' => 1, 'count' => 0];
 JsonRule::evaluate($ruleset, $data); // true
 ```
 
-
-### JsonRule format
-
-`JsonRule` accepts rules defined using a JSON structure that resembles infix notation. Operators are written as keys and their arguments are provided in nested arrays.
-
-```php
-use JakubCiszak\RuleEngine\Api\JsonRule;
-
-$rules = ['and' => [
-    ['<' => [['var' => 'temp'], 110]],
-    ['==' => [['var' => 'pie.filling'], 'apple']],
-]];
-
-$data = ['temp' => 100, 'pie' => ['filling' => 'apple']];
-
-$result = JsonRule::evaluate($rules, $data); // true
-```
-
-You can also pass a set of named rules for evaluation:
-
-```php
-$ruleset = [
-    'rule1' => ['==' => [['var' => 'a'], 1]],
-    'rule2' => ['>' => [['var' => 'b'], 2]],
-];
-
-$data = ['a' => 1, 'b' => 3];
-
-JsonRule::evaluate($ruleset, $data); // true
-```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,44 @@ Supported operators are `+` (addition), `-` (subtraction), `.` (concatenation) a
 
 When using `JsonRule`, specify actions under the `actions` key alongside the rule expression or within each rule of a ruleset.
 
+#### JsonRPN example
+
+```json
+{
+  "rules": [
+    {
+      "name": "rule1",
+      "elements": [
+        {"type": "variable", "name": "a"},
+        {"type": "variable", "name": "b"},
+        {"type": "operator", "name": "EQUAL_TO"}
+      ],
+      "actions": ["var.count + 1"]
+    }
+  ]
+}
+```
+
+Evaluating the JSON above with `{ "a": 1, "b": 1, "count": 0 }` updates `count` to `1` when the rule evaluates to `true`.
+
+#### JsonRule example
+
+```php
+$ruleset = [
+    'rule1' => [
+        '==' => [['var' => 'a'], 1],
+        'actions' => ['var.count + 1'],
+    ],
+    'rule2' => [
+        '==' => [['var' => 'count'], 1],
+    ],
+];
+
+$data = ['a' => 1, 'count' => 0];
+
+JsonRule::evaluate($ruleset, $data); // true
+```
+
 
 ### JsonRule format
 


### PR DESCRIPTION
## Summary
- document how to add `actions` for JsonRPN
- add a JsonRule example with `actions`

## Testing
- `vendor/bin/phpunit --colors=never`


------
https://chatgpt.com/codex/tasks/task_e_688d2da3c6fc8330a0142d9208051445