### PR TITLE
Enable arrays-only evaluation with flat and nested rule APIs

### DIFF
--- a/src/ActivityRule.php
+++ b/src/ActivityRule.php
@@ -14,7 +14,6 @@ final class ActivityRule implements RuleInterface
     public readonly string $name;
 
     /**
-     * @param RuleInterface $rule
      * @param T $activity
      */
     public function __construct(

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -6,9 +6,7 @@ use Munus\Collection\GenericList;
 
 class Rule implements RuleInterface
 {
-    /**
-     * @param GenericList<RuleElement> $elements
-     */
+    /** @var GenericList<RuleElement> */
     private GenericList $elements;
 
     public function __construct(public readonly string $name)

--- a/src/RuleContext.php
+++ b/src/RuleContext.php
@@ -6,9 +6,7 @@ use Munus\Collection\Map;
 
 class RuleContext
 {
-    /**
-     * @param Map<RuleElement> $elements
-     */
+    /** @var Map<RuleElement> */
     private Map $elements;
 
     public function __construct()

--- a/tests/FlatRuleAPITest.php
+++ b/tests/FlatRuleAPITest.php
@@ -2,14 +2,14 @@
 
 namespace JakubCiszak\RuleEngine\Tests;
 
-use JakubCiszak\RuleEngine\Api\JsonRPN;
+use JakubCiszak\RuleEngine\Api\FlatRuleAPI;
 use PHPUnit\Framework\TestCase;
 
-final class JsonRPNTest extends TestCase
+final class FlatRuleAPITest extends TestCase
 {
-    public function testEvaluateJsonRPNs(): void
+    public function testEvaluateFlatRuleAPIs(): void
     {
-        $rulesJson = json_encode([
+        $rules = [
             'rules' => [
                 [
                     'name' => 'rule1',
@@ -28,25 +28,25 @@ final class JsonRPNTest extends TestCase
                     ],
                 ],
             ],
-        ], JSON_THROW_ON_ERROR);
+        ];
 
-        $contextJson = json_encode([
+        $context = [
             'a' => 1,
             'b' => 1,
             'amount' => 50,
             'max' => 100,
-        ], JSON_THROW_ON_ERROR);
+        ];
 
-        $resultJson = JsonRPN::evaluate($rulesJson, $contextJson);
+        $resultJson = FlatRuleAPI::evaluate($rules, $context);
         $result = json_decode($resultJson, true, 512, JSON_THROW_ON_ERROR);
 
         $this->assertTrue($result['results'][0]['value']);
         $this->assertFalse($result['results'][1]['value']);
     }
 
-    public function testEvaluateJsonRPNsWithActions(): void
+    public function testEvaluateFlatRuleAPIsWithActions(): void
     {
-        $rulesJson = json_encode([
+        $rules = [
             'rules' => [
                 [
                     'name' => 'rule1',
@@ -68,16 +68,16 @@ final class JsonRPNTest extends TestCase
                     ],
                 ],
             ],
-        ], JSON_THROW_ON_ERROR);
+        ];
 
-        $contextJson = json_encode([
+        $context = [
             'a' => 1,
             'b' => 1,
             'count' => 0,
             'expected' => 1,
-        ], JSON_THROW_ON_ERROR);
+        ];
 
-        $resultJson = JsonRPN::evaluate($rulesJson, $contextJson);
+        $resultJson = FlatRuleAPI::evaluate($rules, $context);
         $result = json_decode($resultJson, true, 512, JSON_THROW_ON_ERROR);
 
         $this->assertTrue($result['results'][0]['value']);
@@ -86,7 +86,7 @@ final class JsonRPNTest extends TestCase
 
     public function testActionUsingVariableReference(): void
     {
-        $rulesJson = json_encode([
+        $rules = [
             'rules' => [
                 [
                     'name' => 'rule1',
@@ -108,17 +108,17 @@ final class JsonRPNTest extends TestCase
                     ],
                 ],
             ],
-        ], JSON_THROW_ON_ERROR);
+        ];
 
-        $contextJson = json_encode([
+        $context = [
             'x' => 1,
             'y' => 1,
             'count' => 1,
             'increment' => 2,
             'expected' => 3,
-        ], JSON_THROW_ON_ERROR);
+        ];
 
-        $resultJson = JsonRPN::evaluate($rulesJson, $contextJson);
+        $resultJson = FlatRuleAPI::evaluate($rules, $context);
         $result = json_decode($resultJson, true, 512, JSON_THROW_ON_ERROR);
 
         $this->assertTrue($result['results'][0]['value']);
@@ -127,7 +127,7 @@ final class JsonRPNTest extends TestCase
 
     public function testActionSubtract(): void
     {
-        $rulesJson = json_encode([
+        $rules = [
             'rules' => [
                 [
                     'name' => 'rule1',
@@ -149,16 +149,16 @@ final class JsonRPNTest extends TestCase
                     ],
                 ],
             ],
-        ], JSON_THROW_ON_ERROR);
+        ];
 
-        $contextJson = json_encode([
+        $context = [
             'a' => 1,
             'b' => 1,
             'count' => 10,
             'expected' => 8,
-        ], JSON_THROW_ON_ERROR);
+        ];
 
-        $resultJson = JsonRPN::evaluate($rulesJson, $contextJson);
+        $resultJson = FlatRuleAPI::evaluate($rules, $context);
         $result = json_decode($resultJson, true, 512, JSON_THROW_ON_ERROR);
 
         $this->assertTrue($result['results'][0]['value']);
@@ -167,7 +167,7 @@ final class JsonRPNTest extends TestCase
 
     public function testActionConcatenate(): void
     {
-        $rulesJson = json_encode([
+        $rules = [
             'rules' => [
                 [
                     'name' => 'rule1',
@@ -189,15 +189,15 @@ final class JsonRPNTest extends TestCase
                     ],
                 ],
             ],
-        ], JSON_THROW_ON_ERROR);
+        ];
 
-        $contextJson = json_encode([
+        $context = [
             'name' => 'John',
             'before' => 'John',
             'expected' => 'JohnDoe',
-        ], JSON_THROW_ON_ERROR);
+        ];
 
-        $resultJson = JsonRPN::evaluate($rulesJson, $contextJson);
+        $resultJson = FlatRuleAPI::evaluate($rules, $context);
         $result = json_decode($resultJson, true, 512, JSON_THROW_ON_ERROR);
 
         $this->assertTrue($result['results'][0]['value']);
@@ -206,7 +206,7 @@ final class JsonRPNTest extends TestCase
 
     public function testActionSet(): void
     {
-        $rulesJson = json_encode([
+        $rules = [
             'rules' => [
                 [
                     'name' => 'rule1',
@@ -228,19 +228,40 @@ final class JsonRPNTest extends TestCase
                     ],
                 ],
             ],
-        ], JSON_THROW_ON_ERROR);
+        ];
 
-        $contextJson = json_encode([
+        $context = [
             'a' => 1,
             'b' => 1,
             'status' => 'pending',
             'expected' => 'done',
-        ], JSON_THROW_ON_ERROR);
+        ];
 
-        $resultJson = JsonRPN::evaluate($rulesJson, $contextJson);
+        $resultJson = FlatRuleAPI::evaluate($rules, $context);
         $result = json_decode($resultJson, true, 512, JSON_THROW_ON_ERROR);
 
         $this->assertTrue($result['results'][0]['value']);
         $this->assertTrue($result['results'][1]['value']);
+    }
+
+    public function testCallablePropositionInContext(): void
+    {
+        $rules = [
+            'rules' => [
+                [
+                    'name' => 'rule1',
+                    'elements' => [
+                        ['type' => 'proposition', 'name' => 'flag'],
+                    ],
+                ],
+            ],
+        ];
+
+        $context = ['flag' => fn () => true];
+
+        $resultJson = FlatRuleAPI::evaluate($rules, $context);
+        $result = json_decode($resultJson, true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertTrue($result['results'][0]['value']);
     }
 }

--- a/tests/NestedRuleApiTest.php
+++ b/tests/NestedRuleApiTest.php
@@ -2,10 +2,10 @@
 
 namespace JakubCiszak\RuleEngine\Tests;
 
-use JakubCiszak\RuleEngine\Api\JsonRule;
+use JakubCiszak\RuleEngine\Api\NestedRuleApi;
 use PHPUnit\Framework\TestCase;
 
-final class JsonRuleTest extends TestCase
+final class NestedRuleApiTest extends TestCase
 {
     public function testEvaluateArrayRules(): void
     {
@@ -16,7 +16,7 @@ final class JsonRuleTest extends TestCase
 
         $data = ['temp' => 100, 'pie' => ['filling' => 'apple']];
 
-        self::assertTrue(JsonRule::evaluate($rules, $data));
+        self::assertTrue(NestedRuleApi::evaluate($rules, $data));
     }
 
     public function testEvaluateJsonStrings(): void
@@ -27,7 +27,12 @@ final class JsonRuleTest extends TestCase
         $rulesJson = json_encode($rules, JSON_THROW_ON_ERROR);
         $dataJson = json_encode($data, JSON_THROW_ON_ERROR);
 
-        self::assertFalse(JsonRule::evaluate($rulesJson, $dataJson));
+        self::assertFalse(
+            NestedRuleApi::evaluate(
+                json_decode($rulesJson, true, 512, JSON_THROW_ON_ERROR),
+                json_decode($dataJson, true, 512, JSON_THROW_ON_ERROR)
+            )
+        );
     }
 
     public function testEvaluateOrOperator(): void
@@ -39,7 +44,7 @@ final class JsonRuleTest extends TestCase
 
         $data = ['a' => 0, 'b' => 3];
 
-        self::assertTrue(JsonRule::evaluate($rules, $data));
+        self::assertTrue(NestedRuleApi::evaluate($rules, $data));
     }
 
     public function testEvaluateNotOperator(): void
@@ -50,7 +55,7 @@ final class JsonRuleTest extends TestCase
 
         $data = ['a' => 3];
 
-        self::assertTrue(JsonRule::evaluate($rules, $data));
+        self::assertTrue(NestedRuleApi::evaluate($rules, $data));
     }
 
     public function testEvaluateAllComparisonOperators(): void
@@ -73,7 +78,7 @@ final class JsonRuleTest extends TestCase
             'f' => 2,
         ];
 
-        self::assertTrue(JsonRule::evaluate($rules, $data));
+        self::assertTrue(NestedRuleApi::evaluate($rules, $data));
     }
 
     public function testEvaluateRulesetArray(): void
@@ -91,7 +96,7 @@ final class JsonRuleTest extends TestCase
 
         $data = ['temp' => 100, 'pie' => ['filling' => 'apple']];
 
-        self::assertTrue(JsonRule::evaluate($ruleset, $data));
+        self::assertTrue(NestedRuleApi::evaluate($ruleset, $data));
     }
 
     public function testEvaluateRulesetJson(): void
@@ -105,7 +110,12 @@ final class JsonRuleTest extends TestCase
         $rulesetJson = json_encode($ruleset, JSON_THROW_ON_ERROR);
         $dataJson = json_encode($data, JSON_THROW_ON_ERROR);
 
-        self::assertTrue(JsonRule::evaluate($rulesetJson, $dataJson));
+        self::assertTrue(
+            NestedRuleApi::evaluate(
+                json_decode($rulesetJson, true, 512, JSON_THROW_ON_ERROR),
+                json_decode($dataJson, true, 512, JSON_THROW_ON_ERROR)
+            )
+        );
     }
 
     public function testEvaluateRulesetWithActions(): void
@@ -122,7 +132,7 @@ final class JsonRuleTest extends TestCase
 
         $data = ['a' => 1, 'count' => 0];
 
-        self::assertTrue(JsonRule::evaluate($ruleset, $data));
+        self::assertTrue(NestedRuleApi::evaluate($ruleset, $data));
     }
 
     public function testActionUsingVariableReference(): void
@@ -139,7 +149,7 @@ final class JsonRuleTest extends TestCase
 
         $data = ['x' => 1, 'count' => 1, 'increment' => 2];
 
-        self::assertTrue(JsonRule::evaluate($ruleset, $data));
+        self::assertTrue(NestedRuleApi::evaluate($ruleset, $data));
     }
 
     public function testActionSubtract(): void
@@ -156,7 +166,7 @@ final class JsonRuleTest extends TestCase
 
         $data = ['a' => 1, 'count' => 10];
 
-        self::assertTrue(JsonRule::evaluate($ruleset, $data));
+        self::assertTrue(NestedRuleApi::evaluate($ruleset, $data));
     }
 
     public function testActionConcatenate(): void
@@ -173,7 +183,7 @@ final class JsonRuleTest extends TestCase
 
         $data = ['name' => 'John'];
 
-        self::assertTrue(JsonRule::evaluate($ruleset, $data));
+        self::assertTrue(NestedRuleApi::evaluate($ruleset, $data));
     }
 
     public function testActionSet(): void
@@ -190,6 +200,17 @@ final class JsonRuleTest extends TestCase
 
         $data = ['a' => 1, 'status' => 'pending'];
 
-        self::assertTrue(JsonRule::evaluate($ruleset, $data));
+        self::assertTrue(NestedRuleApi::evaluate($ruleset, $data));
+    }
+
+    public function testCallableProposition(): void
+    {
+        $rules = ['and' => [
+            ['var' => 'check'],
+        ]];
+
+        $data = ['check' => fn () => true];
+
+        self::assertTrue(NestedRuleApi::evaluate($rules, $data));
     }
 }


### PR DESCRIPTION
## Summary
- rename `RuleFromRPN` to `FlatRuleAPI` and `RuleFromPN` to `NestedRuleApi`
- update README and examples for the new API names
- adjust tests to cover callable propositions with renamed classes
- revamp README with marketing intro and Rule Archetype overview

## Testing
- `composer dump-autoload`
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_688d42e6753083309062b7218a820f9c