### PR TITLE
feat: add infix string rule API

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Pick the API that matches the shape of your data:
 
 - **FlatRuleAPI** – send a linear array in [Reverse Polish Notation](https://en.wikipedia.org/wiki/Reverse_Polish_notation) for fast stack-based evaluation.
 - **NestedRuleApi** – describe rules as nested associative arrays that read like infix notation.
+- **StringRuleApi** – parse and evaluate human readable infix expressions.
 
 Both APIs accept arrays decoded from JSON and can work with callables inside the evaluation context, giving you a flexible way to run rules or trigger simple actions.
 
@@ -134,6 +135,58 @@ $ruleset = [
 $data = ['a' => 1, 'b' => 3];
 
 NestedRuleApi::evaluate($ruleset, $data); // true
+```
+
+### StringRuleApi usage
+
+`StringRuleApi` accepts conditions written as human readable infix expressions. Variables are denoted by a leading dot and resolved from the supplied data array.
+
+```php
+use JakubCiszak\RuleEngine\Api\StringRuleApi;
+
+$expr = '(.actualAge > 18 or .name is Adam) or (.citizenship is PL and .actualAge > 15)';
+$data = ['actualAge' => 16, 'name' => 'John', 'citizenship' => 'PL'];
+
+$result = StringRuleApi::evaluate($expr, $data); // true
+```
+
+Complex nested conditions are also supported:
+
+```php
+$complex = '((.a > 1 and (.b < 3 or .c is 2)) or ((.d >= 5 and .e <= 10) and not (.f != 7))) and (.g is true or .h is false)';
+$data = [
+    'a' => 2,
+    'b' => 2,
+    'c' => 2,
+    'd' => 5,
+    'e' => 10,
+    'f' => 7,
+    'g' => true,
+    'h' => true,
+];
+
+$result = StringRuleApi::evaluate($complex, $data); // true
+```
+
+`StringRuleApi` can evaluate a set of named expressions as a ruleset, returning a single boolean result:
+
+```php
+$rules = [
+    'adult' => '.actualAge > 18',
+    'plCitizen' => '.citizenship is PL',
+];
+$data = ['actualAge' => 16, 'citizenship' => 'PL'];
+
+$result = StringRuleApi::evaluate($rules, $data); // false
+```
+
+Boolean variables can be referenced directly without explicit comparison and negated using `not`:
+
+```php
+$flags = '.g and not .h';
+$data = ['g' => true, 'h' => false];
+
+StringRuleApi::evaluate($flags, $data); // true
 ```
 
 ### Rule actions

--- a/src/Api/StringRuleApi.php
+++ b/src/Api/StringRuleApi.php
@@ -1,0 +1,237 @@
+<?php
+
+namespace JakubCiszak\RuleEngine\Api;
+
+use JakubCiszak\RuleEngine\{Rule, RuleContext, Operator, Ruleset};
+use InvalidArgumentException;
+
+final class StringRuleApi
+{
+    private static int $constCounter = 0;
+
+    private const PRECEDENCE = [
+        'or' => 1,
+        'and' => 2,
+        'not' => 3,
+        '!' => 3,
+        '>' => 4,
+        '<' => 4,
+        '>=' => 4,
+        '<=' => 4,
+        'is' => 4,
+        '==' => 4,
+        '!=' => 4,
+    ];
+
+    private function __construct()
+    {
+    }
+
+    public static function evaluate(string|array $expression, array $data = []): bool
+    {
+        $context = self::createContext($data);
+
+        if (is_array($expression)) {
+            $rules = array_reduce(
+                array_keys($expression),
+                static function (array $rules, string $name) use ($expression, $data): array {
+                    $expr = $expression[$name];
+                    if (!is_string($expr)) {
+                        throw new InvalidArgumentException('Invalid expression');
+                    }
+                    $rule = new Rule($name);
+                    self::parseExpression($expr, $rule, $data);
+                    $rules[] = $rule;
+
+                    return $rules;
+                },
+                []
+            );
+
+            return (new Ruleset(...$rules))->evaluate($context)->getValue();
+        }
+
+        $rule = new Rule('string_rule');
+        self::parseExpression($expression, $rule, $data);
+
+        return $rule->evaluate($context)->getValue();
+    }
+
+    private static function parseExpression(string $expression, Rule $rule, array $data): void
+    {
+        $tokens = self::tokenize($expression);
+        $rpn = self::toRpn($tokens);
+        $engineRpn = self::toEngineOrder($rpn);
+
+        array_walk(
+            $engineRpn,
+            static fn(string $token) => self::handleToken($token, $rule, $data)
+        );
+    }
+
+    /**
+     * @return string[]
+     */
+    private static function tokenize(string $expression): array
+    {
+        $replacements = ['(' => ' ( ', ')' => ' ) ', '!' => ' ! '];
+        $prepared = strtr($expression, $replacements);
+        return array_values(array_filter(explode(' ', trim($prepared)), static fn($t) => $t !== ''));
+    }
+
+    /**
+     * @param string[] $tokens
+     * @return string[]
+     */
+    private static function toRpn(array $tokens): array
+    {
+        $output = [];
+        $stack = [];
+        foreach ($tokens as $token) {
+            $lower = strtolower($token);
+            if ($token === '(') {
+                $stack[] = $token;
+                continue;
+            }
+            if ($token === ')') {
+                while (!empty($stack) && end($stack) !== '(') {
+                    $output[] = array_pop($stack);
+                }
+                array_pop($stack); // remove '('
+                continue;
+            }
+            if (array_key_exists($lower, self::PRECEDENCE)) {
+                while (!empty($stack)) {
+                    $top = end($stack);
+                    $topLower = strtolower($top);
+                    if ($top !== '(' && (self::PRECEDENCE[$topLower] ?? 0) >= self::PRECEDENCE[$lower]) {
+                        $output[] = array_pop($stack);
+                        continue;
+                    }
+                    break;
+                }
+                $stack[] = $token;
+                continue;
+            }
+            $output[] = $token;
+        }
+        while (!empty($stack)) {
+            $output[] = array_pop($stack);
+        }
+        return $output;
+    }
+
+    /**
+     * @param string[] $rpn
+     * @return string[]
+     */
+    private static function toEngineOrder(array $rpn): array
+    {
+        $stack = [];
+        foreach ($rpn as $token) {
+            $lower = strtolower($token);
+            if (array_key_exists($lower, self::PRECEDENCE)) {
+                if ($lower === 'not' || $lower === '!') {
+                    $operand = array_pop($stack);
+                    $stack[] = array_merge($operand, [$token]);
+                } else {
+                    $right = array_pop($stack);
+                    $left = array_pop($stack);
+                    $stack[] = array_merge($right, $left, [$token]);
+                }
+            } else {
+                $stack[] = [$token];
+            }
+        }
+
+        return $stack[0] ?? [];
+    }
+
+    private static function handleToken(string $token, Rule $rule, array $data): void
+    {
+        $lower = strtolower($token);
+        if (array_key_exists($lower, self::PRECEDENCE)) {
+            $rule->addElement(self::mapOperator($lower));
+            return;
+        }
+        if (str_starts_with($token, '.')) {
+            self::addVariable(substr($token, 1), $rule, $data);
+            return;
+        }
+        self::addConstant(self::parseValue($token), $rule);
+    }
+
+    private static function mapOperator(string $op): Operator
+    {
+        return match ($op) {
+            'and' => Operator::AND,
+            'or' => Operator::OR,
+            'not', '!' => Operator::NOT,
+            '>' => Operator::GREATER_THAN,
+            '<' => Operator::LESS_THAN,
+            '>=' => Operator::GREATER_THAN_OR_EQUAL_TO,
+            '<=' => Operator::LESS_THAN_OR_EQUAL_TO,
+            'is', '==' => Operator::EQUAL_TO,
+            '!=' => Operator::NOT_EQUAL_TO,
+            default => throw new InvalidArgumentException('Unsupported operator'),
+        };
+    }
+
+    private static function parseValue(string $value): mixed
+    {
+        if (is_numeric($value)) {
+            return $value + 0; // cast to int or float
+        }
+        $lower = strtolower($value);
+        if ($lower === 'true') {
+            return true;
+        }
+        if ($lower === 'false') {
+            return false;
+        }
+        return $value;
+    }
+
+    private static function addVariable(string $path, Rule $rule, array $data): void
+    {
+        $value = self::extractVar($data, $path);
+        if (is_bool($value) || is_callable($value)) {
+            $rule->proposition($path, $value ?? true);
+        } else {
+            $rule->variable($path, $value);
+        }
+    }
+
+    private static function addConstant(mixed $value, Rule $rule): void
+    {
+        $name = '#const' . ++self::$constCounter;
+        $rule->variable($name, $value);
+    }
+
+    private static function extractVar(array $data, string $path): mixed
+    {
+        return array_reduce(
+            explode('.', $path),
+            static fn($carry, $part) => is_array($carry) && array_key_exists($part, $carry) ? $carry[$part] : null,
+            $data
+        );
+    }
+
+    private static function createContext(array $data): RuleContext
+    {
+        $context = new RuleContext();
+
+        array_walk(
+            $data,
+            static function ($value, $name) use ($context): void {
+                if (is_bool($value) || is_callable($value)) {
+                    $context->proposition($name, $value);
+                } else {
+                    $context->variable($name, $value);
+                }
+            }
+        );
+
+        return $context;
+    }
+}

--- a/tests/StringRuleApiTest.php
+++ b/tests/StringRuleApiTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace JakubCiszak\RuleEngine\Tests;
+
+use JakubCiszak\RuleEngine\Api\StringRuleApi;
+use PHPUnit\Framework\TestCase;
+
+final class StringRuleApiTest extends TestCase
+{
+    public function testEvaluateSimpleExpression(): void
+    {
+        $expr = '.a > 1 and .b < 3';
+        $data = ['a' => 2, 'b' => 2];
+
+        self::assertTrue(StringRuleApi::evaluate($expr, $data));
+    }
+
+    public function testEvaluateNestedExpression(): void
+    {
+        $expr = '(.actualAge > 18 or .name is Adam) or (.citizenship is PL and .actualAge > 15)';
+        $data = ['actualAge' => 16, 'name' => 'John', 'citizenship' => 'PL'];
+
+        self::assertTrue(StringRuleApi::evaluate($expr, $data));
+    }
+
+    public function testEvaluateNotOperator(): void
+    {
+        $expr = '.a is 1 and not (.b < 2)';
+        $data = ['a' => 1, 'b' => 3];
+
+        self::assertTrue(StringRuleApi::evaluate($expr, $data));
+    }
+
+    public function testEvaluateRuleset(): void
+    {
+        $expressions = [
+            'age' => '.age > 18',
+            'name' => '.name is John',
+        ];
+        $data = ['age' => 20, 'name' => 'John'];
+
+        self::assertTrue(StringRuleApi::evaluate($expressions, $data));
+        self::assertFalse(StringRuleApi::evaluate($expressions, ['age' => 20, 'name' => 'Jane']));
+    }
+
+    public function testEvaluateDeeplyNestedExpression(): void
+    {
+        $expr = '((.a > 1 and (.b < 3 or .c is 2)) or ((.d >= 5 and .e <= 10) and not (.f != 7))) and (.g is true or .h is false)';
+        $data = [
+            'a' => 2,
+            'b' => 2,
+            'c' => 2,
+            'd' => 5,
+            'e' => 10,
+            'f' => 7,
+            'g' => true,
+            'h' => true,
+        ];
+
+        self::assertTrue(StringRuleApi::evaluate($expr, $data));
+    }
+
+    public function testEvaluateVeryComplexExpression(): void
+    {
+        $expr = '((.a > 5 and (.b < 3 or (.c is 2 and (.d > 4 or (.e < 5 and .f is 6))))) or (.g <= 7 and (.h != 8 or (.i >= 9 and .j <= 10)))) and not (.k)';
+        $data = [
+            'a' => 2,
+            'b' => 2,
+            'c' => 2,
+            'd' => 5,
+            'e' => 4,
+            'f' => 6,
+            'g' => 7,
+            'h' => 8,
+            'i' => 10,
+            'j' => 9,
+            'k' => true,
+        ];
+
+        self::assertFalse(StringRuleApi::evaluate($expr, $data));
+    }
+
+    public function testEvaluateBooleanVariablesWithoutExplicitComparison(): void
+    {
+        $expr = '.g and .x';
+        $data = ['g' => true, 'x' => true];
+
+        self::assertTrue(StringRuleApi::evaluate($expr, $data));
+        self::assertFalse(StringRuleApi::evaluate($expr, ['g' => true, 'x' => false]));
+    }
+
+    public function testEvaluateNotOnBooleanVariable(): void
+    {
+        $expr = 'not .g';
+        $data = ['g' => false];
+
+        self::assertTrue(StringRuleApi::evaluate($expr, $data));
+        self::assertFalse(StringRuleApi::evaluate($expr, ['g' => true]));
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `StringRuleApi` to parse and evaluate infix expressions
- evaluate arrays of named string rules as a ruleset returning a single boolean
- allow boolean variables to be used directly and negated with `not`
- document complex and boolean shorthand examples in README
- refactor API internals to rely on array helpers for clearer, functional style

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_688e09202c7c8330a4979eceb1420429