### PR TITLE
Ensure activities run only on successful rules and adopt dot notation for actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,12 +193,12 @@ StringRuleApi::evaluate($flags, $data); // true
 Each rule may include simple actions executed when the rule is evaluated. Actions are expressed as strings:
 
 ```
-"var.count + 5"
-"var.name = John"
-"var.total + var.amount"
+".count + 5"
+".name = John"
+".total + .amount"
 ```
 
-Supported operators are `+` (addition), `-` (subtraction), `.` (concatenation) and `=` (assignment). Values starting with `var.` reference variables from the evaluation context.
+Supported operators are `+` (addition), `-` (subtraction), `.` (concatenation) and `=` (assignment). Values starting with `.` reference variables from the evaluation context.
 
 When using `NestedRuleApi`, specify actions under the `actions` key alongside the rule expression or within each rule of a ruleset.
 
@@ -214,7 +214,7 @@ When using `NestedRuleApi`, specify actions under the `actions` key alongside th
         {"type": "variable", "name": "b"},
         {"type": "operator", "name": "EQUAL_TO"}
       ],
-      "actions": ["var.count + 1"]
+       "actions": [".count + 1"]
     }
   ]
 }
@@ -235,7 +235,7 @@ FlatRuleAPI::evaluate($rules, $context);
 $ruleset = [
     'rule1' => [
         '==' => [['var' => 'a'], 1],
-        'actions' => ['var.count + 1'],
+        'actions' => ['.count + 1'],
     ],
     'rule2' => [
         '==' => [['var' => 'count'], 1],

--- a/src/ActivityRule.php
+++ b/src/ActivityRule.php
@@ -118,7 +118,9 @@ final class ActivityRule implements RuleInterface
     public function evaluate(RuleContext $context): Proposition
     {
         $result = $this->rule->evaluate($context);
-        ($this->activity)($context);
+        if ($result->getValue()) {
+            ($this->activity)($context);
+        }
 
         return $result;
     }

--- a/src/Api/ActionParser.php
+++ b/src/Api/ActionParser.php
@@ -23,11 +23,11 @@ final class ActionParser
 
     private static function parseVariable(string $token): string
     {
-        if (!str_starts_with($token, 'var.')) {
+        if (!str_starts_with($token, '.')) {
             throw new InvalidArgumentException('Action target must be a variable');
         }
 
-        return substr($token, 4);
+        return substr($token, 1);
     }
 
     private static function parseOperator(string $token): ActionType
@@ -45,8 +45,8 @@ final class ActionParser
     {
         $token = trim($token);
 
-        if (str_starts_with($token, 'var.')) {
-            return Variable::create(substr($token, 4));
+        if (str_starts_with($token, '.')) {
+            return Variable::create(substr($token, 1));
         }
 
         if (is_numeric($token)) {

--- a/tests/ActivityRuleTest.php
+++ b/tests/ActivityRuleTest.php
@@ -39,4 +39,31 @@ class ActivityRuleTest extends TestCase
         $this->assertInstanceOf(Variable::class, $variable);
         $this->assertTrue($variable->getValue());
     }
+
+    public function testActivityNotExecutedWhenRuleFails(): void
+    {
+        $rule = new Rule('someRule');
+        $rule->variable('a')
+            ->variable('b')
+            ->equalTo();
+
+        $called = false;
+        $activity = function (RuleContext $context) use (&$called) {
+            $called = true;
+            $context->variable('activity', true);
+        };
+
+        $activityRule = new ActivityRule($rule, $activity);
+
+        $context = new RuleContext();
+        $context->variable('a', 1)
+            ->variable('b', 2);
+
+        $result = $activityRule->evaluate($context);
+
+        $this->assertFalse($result->getValue());
+        $this->assertFalse($called);
+        $variable = $context->findElement(Variable::create('activity'));
+        $this->assertNull($variable);
+    }
 }

--- a/tests/FlatRuleAPITest.php
+++ b/tests/FlatRuleAPITest.php
@@ -54,7 +54,7 @@ final class FlatRuleAPITest extends TestCase
                         ['type' => 'operator', 'name' => 'EQUAL_TO'],
                     ],
                     'actions' => [
-                        'var.count + 1',
+                        '.count + 1',
                     ],
                 ],
                 [
@@ -93,7 +93,7 @@ final class FlatRuleAPITest extends TestCase
                         ['type' => 'operator', 'name' => 'EQUAL_TO'],
                     ],
                     'actions' => [
-                        'var.count + var.increment',
+                        '.count + .increment',
                     ],
                 ],
                 [
@@ -133,7 +133,7 @@ final class FlatRuleAPITest extends TestCase
                         ['type' => 'operator', 'name' => 'EQUAL_TO'],
                     ],
                     'actions' => [
-                        'var.count - 2',
+                        '.count - 2',
                     ],
                 ],
                 [
@@ -172,7 +172,7 @@ final class FlatRuleAPITest extends TestCase
                         ['type' => 'operator', 'name' => 'EQUAL_TO'],
                     ],
                     'actions' => [
-                        'var.name . Doe',
+                        '.name . Doe',
                     ],
                 ],
                 [
@@ -210,7 +210,7 @@ final class FlatRuleAPITest extends TestCase
                         ['type' => 'operator', 'name' => 'EQUAL_TO'],
                     ],
                     'actions' => [
-                        'var.status = done',
+                        '.status = done',
                     ],
                 ],
                 [

--- a/tests/NestedRuleApiTest.php
+++ b/tests/NestedRuleApiTest.php
@@ -129,7 +129,7 @@ final class NestedRuleApiTest extends TestCase
         $ruleset = [
             'rule1' => [
                 '==' => [['var' => 'a'], 1],
-                'actions' => ['var.count + 1'],
+                'actions' => ['.count + 1'],
             ],
             'rule2' => [
                 '==' => [['var' => 'count'], 1],
@@ -147,7 +147,7 @@ final class NestedRuleApiTest extends TestCase
         $ruleset = [
             'rule1' => [
                 '==' => [['var' => 'x'], 1],
-                'actions' => ['var.count + var.increment'],
+                'actions' => ['.count + .increment'],
             ],
             'rule2' => [
                 '==' => [['var' => 'count'], 3],
@@ -165,7 +165,7 @@ final class NestedRuleApiTest extends TestCase
         $ruleset = [
             'rule1' => [
                 '==' => [['var' => 'a'], 1],
-                'actions' => ['var.count - 2'],
+                'actions' => ['.count - 2'],
             ],
             'rule2' => [
                 '==' => [['var' => 'count'], 8],
@@ -183,7 +183,7 @@ final class NestedRuleApiTest extends TestCase
         $ruleset = [
             'rule1' => [
                 '==' => [['var' => 'name'], 'John'],
-                'actions' => ['var.name . Doe'],
+                'actions' => ['.name . Doe'],
             ],
             'rule2' => [
                 '==' => [['var' => 'name'], 'JohnDoe'],
@@ -201,7 +201,7 @@ final class NestedRuleApiTest extends TestCase
         $ruleset = [
             'rule1' => [
                 '==' => [['var' => 'a'], 1],
-                'actions' => ['var.status = done'],
+                'actions' => ['.status = done'],
             ],
             'rule2' => [
                 '==' => [['var' => 'status'], 'done'],


### PR DESCRIPTION
## Summary
- Run activity callbacks only when the wrapped rule evaluates to true
- Accept dot-prefixed variable references in action strings and update docs
- Add regression tests for action parser and activity rule behavior

## Testing
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_688e829934d4833090199eeeacc299ff