### PR TITLE
Add tests for initializing missing variables in actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Rules can also be defined using JSON in RPN order. The example below presents tw
       "elements": [
         {"type": "variable", "name": "a"},
         {"type": "variable", "name": "b"},
-        {"type": "operator", "name": "EQUAL_TO"}
+        {"type": "operator", "name": "=="}
       ]
     },
     {
@@ -88,7 +88,7 @@ Rules can also be defined using JSON in RPN order. The example below presents tw
       "elements": [
         {"type": "variable", "name": "amount"},
         {"type": "variable", "name": "max"},
-        {"type": "operator", "name": "GREATER_THAN"}
+        {"type": "operator", "name": ">"}
       ]
     }
   ]
@@ -212,7 +212,7 @@ When using `NestedRuleApi`, specify actions under the `actions` key alongside th
       "elements": [
         {"type": "variable", "name": "a"},
         {"type": "variable", "name": "b"},
-        {"type": "operator", "name": "EQUAL_TO"}
+        {"type": "operator", "name": "=="}
       ],
        "actions": [".count + 1"]
     }

--- a/src/Api/NestedRuleApi.php
+++ b/src/Api/NestedRuleApi.php
@@ -88,7 +88,7 @@ final class NestedRuleApi
                 self::parseExpression($value, $rule, $data);
 
                 if ($index > 0) {
-                    $rule->addElement(Operator::create(strtoupper($operator)));
+                    $rule->addElement(Operator::create($operator));
                 }
             },
             $values,
@@ -107,17 +107,7 @@ final class NestedRuleApi
         self::parseExpression($values[1] ?? null, $rule, $data);
         self::parseExpression($values[0] ?? null, $rule, $data);
 
-        $op = match ($operator) {
-            '==' => Operator::EQUAL_TO,
-            '!=' => Operator::NOT_EQUAL_TO,
-            '>' => Operator::GREATER_THAN,
-            '<' => Operator::LESS_THAN,
-            '>=' => Operator::GREATER_THAN_OR_EQUAL_TO,
-            '<=' => Operator::LESS_THAN_OR_EQUAL_TO,
-            'in' => Operator::IN,
-        };
-
-        $rule->addElement($op);
+        $rule->addElement(Operator::create($operator));
     }
 
     private static function addVariable(string $path, Rule $rule, array $data): void

--- a/src/Api/StringRuleApi.php
+++ b/src/Api/StringRuleApi.php
@@ -163,18 +163,7 @@ final class StringRuleApi
 
     private static function mapOperator(string $op): Operator
     {
-        return match ($op) {
-            'and' => Operator::AND,
-            'or' => Operator::OR,
-            'not', '!' => Operator::NOT,
-            '>' => Operator::GREATER_THAN,
-            '<' => Operator::LESS_THAN,
-            '>=' => Operator::GREATER_THAN_OR_EQUAL_TO,
-            '<=' => Operator::LESS_THAN_OR_EQUAL_TO,
-            'is', '==' => Operator::EQUAL_TO,
-            '!=' => Operator::NOT_EQUAL_TO,
-            default => throw new InvalidArgumentException('Unsupported operator'),
-        };
+        return Operator::create($op);
     }
 
     private static function parseValue(string $value): mixed

--- a/src/Operator.php
+++ b/src/Operator.php
@@ -2,6 +2,8 @@
 
 namespace JakubCiszak\RuleEngine;
 
+use InvalidArgumentException;
+
 enum Operator implements RuleElement
 {
     case AND;
@@ -25,19 +27,20 @@ enum Operator implements RuleElement
         return RuleElementType::OPERATOR;
     }
 
-    public static function create(string $name): static
+    public static function create(string $symbol): static
     {
-        return match ($name) {
-            'AND' => self::AND,
-            'OR' => self::OR,
-            'NOT' => self::NOT,
-            'EQUAL_TO' => self::EQUAL_TO,
-            'NOT_EQUAL_TO' => self::NOT_EQUAL_TO,
-            'GREATER_THAN' => self::GREATER_THAN,
-            'LESS_THAN' => self::LESS_THAN,
-            'GREATER_THAN_OR_EQUAL_TO' => self::GREATER_THAN_OR_EQUAL_TO,
-            'LESS_THAN_OR_EQUAL_TO' => self::LESS_THAN_OR_EQUAL_TO,
-            'IN' => self::IN,
+        return match (strtolower($symbol)) {
+            'and' => self::AND,
+            'or' => self::OR,
+            'not', '!' => self::NOT,
+            '==', 'is', 'equal_to' => self::EQUAL_TO,
+            '!=', 'not_equal_to' => self::NOT_EQUAL_TO,
+            '>' , 'greater_than' => self::GREATER_THAN,
+            '<', 'less_than' => self::LESS_THAN,
+            '>=' , 'greater_than_or_equal_to' => self::GREATER_THAN_OR_EQUAL_TO,
+            '<=', 'less_than_or_equal_to' => self::LESS_THAN_OR_EQUAL_TO,
+            'in' => self::IN,
+            default => throw new InvalidArgumentException('Unsupported operator'),
         };
     }
 

--- a/tests/FlatRuleAPITest.php
+++ b/tests/FlatRuleAPITest.php
@@ -16,7 +16,7 @@ final class FlatRuleAPITest extends TestCase
                     'elements' => [
                         ['type' => 'variable', 'name' => 'a'],
                         ['type' => 'variable', 'name' => 'b'],
-                        ['type' => 'operator', 'name' => 'EQUAL_TO'],
+                        ['type' => 'operator', 'name' => '=='],
                     ],
                 ],
                 [
@@ -24,7 +24,7 @@ final class FlatRuleAPITest extends TestCase
                     'elements' => [
                         ['type' => 'variable', 'name' => 'max'],
                         ['type' => 'variable', 'name' => 'amount'],
-                        ['type' => 'operator', 'name' => 'GREATER_THAN'],
+                        ['type' => 'operator', 'name' => '>'],
                     ],
                 ],
             ],
@@ -51,7 +51,7 @@ final class FlatRuleAPITest extends TestCase
                     'elements' => [
                         ['type' => 'variable', 'name' => 'a'],
                         ['type' => 'variable', 'name' => 'b'],
-                        ['type' => 'operator', 'name' => 'EQUAL_TO'],
+                        ['type' => 'operator', 'name' => '=='],
                     ],
                     'actions' => [
                         '.count + 1',
@@ -62,7 +62,7 @@ final class FlatRuleAPITest extends TestCase
                     'elements' => [
                         ['type' => 'variable', 'name' => 'count'],
                         ['type' => 'variable', 'name' => 'expected'],
-                        ['type' => 'operator', 'name' => 'EQUAL_TO'],
+                        ['type' => 'operator', 'name' => '=='],
                     ],
                 ],
             ],
@@ -90,7 +90,7 @@ final class FlatRuleAPITest extends TestCase
                     'elements' => [
                         ['type' => 'variable', 'name' => 'x'],
                         ['type' => 'variable', 'name' => 'y'],
-                        ['type' => 'operator', 'name' => 'EQUAL_TO'],
+                        ['type' => 'operator', 'name' => '=='],
                     ],
                     'actions' => [
                         '.count + .increment',
@@ -101,7 +101,7 @@ final class FlatRuleAPITest extends TestCase
                     'elements' => [
                         ['type' => 'variable', 'name' => 'count'],
                         ['type' => 'variable', 'name' => 'expected'],
-                        ['type' => 'operator', 'name' => 'EQUAL_TO'],
+                        ['type' => 'operator', 'name' => '=='],
                     ],
                 ],
             ],
@@ -130,7 +130,7 @@ final class FlatRuleAPITest extends TestCase
                     'elements' => [
                         ['type' => 'variable', 'name' => 'a'],
                         ['type' => 'variable', 'name' => 'b'],
-                        ['type' => 'operator', 'name' => 'EQUAL_TO'],
+                        ['type' => 'operator', 'name' => '=='],
                     ],
                     'actions' => [
                         '.count - 2',
@@ -141,7 +141,7 @@ final class FlatRuleAPITest extends TestCase
                     'elements' => [
                         ['type' => 'variable', 'name' => 'count'],
                         ['type' => 'variable', 'name' => 'expected'],
-                        ['type' => 'operator', 'name' => 'EQUAL_TO'],
+                        ['type' => 'operator', 'name' => '=='],
                     ],
                 ],
             ],
@@ -169,7 +169,7 @@ final class FlatRuleAPITest extends TestCase
                     'elements' => [
                         ['type' => 'variable', 'name' => 'name'],
                         ['type' => 'variable', 'name' => 'before'],
-                        ['type' => 'operator', 'name' => 'EQUAL_TO'],
+                        ['type' => 'operator', 'name' => '=='],
                     ],
                     'actions' => [
                         '.name . Doe',
@@ -180,7 +180,7 @@ final class FlatRuleAPITest extends TestCase
                     'elements' => [
                         ['type' => 'variable', 'name' => 'name'],
                         ['type' => 'variable', 'name' => 'expected'],
-                        ['type' => 'operator', 'name' => 'EQUAL_TO'],
+                        ['type' => 'operator', 'name' => '=='],
                     ],
                 ],
             ],
@@ -207,7 +207,7 @@ final class FlatRuleAPITest extends TestCase
                     'elements' => [
                         ['type' => 'variable', 'name' => 'a'],
                         ['type' => 'variable', 'name' => 'b'],
-                        ['type' => 'operator', 'name' => 'EQUAL_TO'],
+                        ['type' => 'operator', 'name' => '=='],
                     ],
                     'actions' => [
                         '.status = done',
@@ -218,7 +218,7 @@ final class FlatRuleAPITest extends TestCase
                     'elements' => [
                         ['type' => 'variable', 'name' => 'status'],
                         ['type' => 'variable', 'name' => 'expected'],
-                        ['type' => 'operator', 'name' => 'EQUAL_TO'],
+                        ['type' => 'operator', 'name' => '=='],
                     ],
                 ],
             ],
@@ -255,5 +255,40 @@ final class FlatRuleAPITest extends TestCase
         $result = FlatRuleAPI::evaluate($rules, $context);
 
         $this->assertTrue($result);
+    }
+
+    public function testActionInitializesMissingVariable(): void
+    {
+        $rules = [
+            'rules' => [
+                [
+                    'name' => 'rule1',
+                    'elements' => [
+                        ['type' => 'variable', 'name' => 'a'],
+                        ['type' => 'variable', 'name' => 'b'],
+                        ['type' => 'operator', 'name' => '=='],
+                    ],
+                    'actions' => ['.generated + 1'],
+                ],
+                [
+                    'name' => 'rule2',
+                    'elements' => [
+                        ['type' => 'variable', 'name' => 'generated'],
+                        ['type' => 'variable', 'name' => 'expected', 'value' => 1],
+                        ['type' => 'operator', 'name' => '=='],
+                    ],
+                ],
+            ],
+        ];
+
+        $context = [
+            'a' => 1,
+            'b' => 1,
+        ];
+
+        $result = FlatRuleAPI::evaluate($rules, $context);
+
+        $this->assertTrue($result);
+        $this->assertSame(1, $context['generated']);
     }
 }

--- a/tests/NestedRuleApiTest.php
+++ b/tests/NestedRuleApiTest.php
@@ -224,4 +224,22 @@ final class NestedRuleApiTest extends TestCase
 
         self::assertTrue(NestedRuleApi::evaluate($rules, $data));
     }
+
+    public function testActionInitializesMissingVariable(): void
+    {
+        $ruleset = [
+            'rule1' => [
+                '==' => [['var' => 'a'], 1],
+                'actions' => ['.generated + 1'],
+            ],
+            'rule2' => [
+                '==' => [['var' => 'generated'], 1],
+            ],
+        ];
+
+        $data = ['a' => 1];
+
+        self::assertTrue(NestedRuleApi::evaluate($ruleset, $data));
+        self::assertSame(1, $data['generated']);
+    }
 }


### PR DESCRIPTION
## Summary
- add FlatRuleAPI test verifying actions can create variables for subsequent rules
- add NestedRuleApi test covering same scenario
- standardize operator tokens across APIs using shared mapping

## Testing
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_688e866225888330ab3f1091286d15e8